### PR TITLE
fix: highlight extension readme code blocks

### DIFF
--- a/packages/markdown-worker/src/parts/GetCodeBlockLanguage/GetCodeBlockLanguage.ts
+++ b/packages/markdown-worker/src/parts/GetCodeBlockLanguage/GetCodeBlockLanguage.ts
@@ -1,0 +1,19 @@
+import type { MarkdownLanguage } from '../MarkDownOptions/MarkDownOptions.ts'
+
+const matchesLanguage = (language: MarkdownLanguage, languageId: string): boolean => {
+  if (language.id.toLowerCase() === languageId) {
+    return true
+  }
+  if (language.aliases?.some((alias) => alias.toLowerCase() === languageId)) {
+    return true
+  }
+  return Boolean(language.extensions?.some((extension) => extension.replace(/^\./, '').toLowerCase() === languageId))
+}
+
+export const getCodeBlockLanguage = (info: string, languages: readonly MarkdownLanguage[]): MarkdownLanguage | undefined => {
+  const languageId = info.trim().split(/\s+/, 1)[0]?.toLowerCase()
+  if (!languageId) {
+    return undefined
+  }
+  return languages.find((language) => Boolean(language.tokenize) && matchesLanguage(language, languageId))
+}

--- a/packages/markdown-worker/src/parts/InitializeSyntaxHighlightingWorker/InitializeSyntaxHighlightingWorker.ts
+++ b/packages/markdown-worker/src/parts/InitializeSyntaxHighlightingWorker/InitializeSyntaxHighlightingWorker.ts
@@ -1,0 +1,12 @@
+import { LazyTransferMessagePortRpcParent } from '@lvce-editor/rpc'
+import { RendererWorker, SyntaxHighlightingWorker } from '@lvce-editor/rpc-registry'
+
+export const initializeSyntaxHighlightingWorker = async (): Promise<void> => {
+  const rpc = await LazyTransferMessagePortRpcParent.create({
+    commandMap: {},
+    send(port) {
+      return RendererWorker.sendMessagePortToSyntaxHighlightingWorker(port)
+    },
+  })
+  SyntaxHighlightingWorker.set(rpc)
+}

--- a/packages/markdown-worker/src/parts/Main/Main.ts
+++ b/packages/markdown-worker/src/parts/Main/Main.ts
@@ -1,5 +1,7 @@
+import * as InitializeSyntaxHighlightingWorker from '../InitializeSyntaxHighlightingWorker/InitializeSyntaxHighlightingWorker.ts'
 import * as Listen from '../Listen/Listen.ts'
 
 export const main = async (): Promise<void> => {
   await Listen.listen()
+  await InitializeSyntaxHighlightingWorker.initializeSyntaxHighlightingWorker()
 }

--- a/packages/markdown-worker/src/parts/MarkDownOptions/MarkDownOptions.ts
+++ b/packages/markdown-worker/src/parts/MarkDownOptions/MarkDownOptions.ts
@@ -1,4 +1,12 @@
+export interface MarkdownLanguage {
+  readonly aliases?: readonly string[]
+  readonly extensions?: readonly string[]
+  readonly id: string
+  readonly tokenize?: string
+}
+
 export interface MarkDownOptions {
   readonly baseUrl?: string
+  readonly languages?: readonly MarkdownLanguage[]
   readonly linksExternal?: boolean
 }

--- a/packages/markdown-worker/src/parts/RenderHighlightedCodeBlock/RenderHighlightedCodeBlock.ts
+++ b/packages/markdown-worker/src/parts/RenderHighlightedCodeBlock/RenderHighlightedCodeBlock.ts
@@ -1,0 +1,18 @@
+const escapeHtml = (value: string): string => {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#39;')
+}
+
+const renderLine = (line: readonly string[]): string => {
+  let html = ''
+  for (let index = 0; index < line.length; index += 2) {
+    const text = line[index] || ''
+    const className = line[index + 1] || 'Token Unknown'
+    html += `<span class="${escapeHtml(className)}">${escapeHtml(text)}</span>`
+  }
+  return html
+}
+
+export const renderHighlightedCodeBlock = (languageId: string, lineInfos: readonly (readonly string[])[]): string => {
+  const code = lineInfos.map(renderLine).join('\n')
+  return `<pre><code class="language-${escapeHtml(languageId)}">${code}\n</code></pre>\n`
+}

--- a/packages/markdown-worker/src/parts/RenderMarkdown/RenderMarkdown.ts
+++ b/packages/markdown-worker/src/parts/RenderMarkdown/RenderMarkdown.ts
@@ -1,12 +1,20 @@
 /* eslint-disable @typescript-eslint/prefer-readonly-parameter-types */
+import { SyntaxHighlightingWorker } from '@lvce-editor/rpc-registry'
 import * as marked from 'marked'
 import type { MarkDownOptions } from '../MarkDownOptions/MarkDownOptions.ts'
+import * as GetCodeBlockLanguage from '../GetCodeBlockLanguage/GetCodeBlockLanguage.ts'
 import { joinUrl } from '../JoinUrl/JoinUrl.ts'
+import * as RenderHighlightedCodeBlock from '../RenderHighlightedCodeBlock/RenderHighlightedCodeBlock.ts'
 
 const RE_LINK_START = /^<a /
 
 export const renderMarkdown = async (markdown: string, options: MarkDownOptions = {}): Promise<string> => {
   const renderer = new marked.Renderer()
+  const highlightedCodeBlocks = new WeakMap<marked.Tokens.Code, string>()
+  const codeRenderer = renderer.code.bind(renderer)
+  renderer.code = (token): string => {
+    return highlightedCodeBlocks.get(token) || codeRenderer(token)
+  }
   if (options.linksExternal) {
     const linkRenderer = renderer.link.bind(renderer)
     renderer.link = (link): string => {
@@ -24,6 +32,26 @@ export const renderMarkdown = async (markdown: string, options: MarkDownOptions 
       return html
     }
   }
-  const html = await marked.marked(markdown, { renderer })
+  const walkTokens = async (token: marked.Token): Promise<void> => {
+    if (token.type !== 'code' || !token.lang) {
+      return
+    }
+    const codeToken = token as marked.Tokens.Code
+    const languageId = codeToken.lang as string
+    const language = GetCodeBlockLanguage.getCodeBlockLanguage(languageId, options.languages || [])
+    if (!language?.tokenize) {
+      return
+    }
+    try {
+      const lineInfos = await SyntaxHighlightingWorker.invoke('Tokenizer.tokenizeCodeBlock', codeToken.text, language.id, language.tokenize)
+      if (Array.isArray(lineInfos)) {
+        const codeBlockLanguageId = languageId.trim().split(/\s+/, 1)[0]
+        highlightedCodeBlocks.set(codeToken, RenderHighlightedCodeBlock.renderHighlightedCodeBlock(codeBlockLanguageId, lineInfos))
+      }
+    } catch {
+      // Keep the normal escaped code block when syntax highlighting is unavailable.
+    }
+  }
+  const html = await marked.marked(markdown, { async: true, renderer, walkTokens })
   return html
 }

--- a/packages/markdown-worker/test/GetCodeBlockLanguage.test.ts
+++ b/packages/markdown-worker/test/GetCodeBlockLanguage.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@jest/globals'
+import { getCodeBlockLanguage } from '../src/parts/GetCodeBlockLanguage/GetCodeBlockLanguage.ts'
+
+const languages = [
+  {
+    extensions: ['.js', '.mjs'],
+    id: 'javascript',
+    tokenize: '/extensions/javascript/tokenize.js',
+  },
+  {
+    aliases: ['Shell Script', 'shell'],
+    extensions: ['.sh', '.bash'],
+    id: 'shellscript',
+    tokenize: '/extensions/shellscript/tokenize.js',
+  },
+  {
+    id: 'plaintext',
+  },
+]
+
+test('returns language matching id', () => {
+  expect(getCodeBlockLanguage('JavaScript', languages)).toEqual(languages[0])
+})
+
+test('returns language matching file extension alias', () => {
+  expect(getCodeBlockLanguage('sh', languages)).toEqual(languages[1])
+})
+
+test('returns language matching contributed alias', () => {
+  expect(getCodeBlockLanguage('shell title=setup', languages)).toEqual(languages[1])
+})
+
+test('ignores languages without tokenizers', () => {
+  expect(getCodeBlockLanguage('plaintext', languages)).toBeUndefined()
+})
+
+test('returns undefined for empty or unknown languages', () => {
+  expect(getCodeBlockLanguage('', languages)).toBeUndefined()
+  expect(getCodeBlockLanguage('unknown', languages)).toBeUndefined()
+})

--- a/packages/markdown-worker/test/RenderHighlightedCodeBlock.test.ts
+++ b/packages/markdown-worker/test/RenderHighlightedCodeBlock.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@jest/globals'
+import { renderHighlightedCodeBlock } from '../src/parts/RenderHighlightedCodeBlock/RenderHighlightedCodeBlock.ts'
+
+test('renders tokenized lines', () => {
+  expect(
+    renderHighlightedCodeBlock('javascript', [
+      ['const', 'Token Keyword', ' answer = ', 'Token Text', '42', 'Token Number'],
+      ['console.log(answer)', 'Token Text'],
+    ]),
+  ).toBe(
+    '<pre><code class="language-javascript"><span class="Token Keyword">const</span><span class="Token Text"> answer = </span><span class="Token Number">42</span>\n<span class="Token Text">console.log(answer)</span>\n</code></pre>\n',
+  )
+})
+
+test('escapes token text, class names, and language ids', () => {
+  expect(renderHighlightedCodeBlock('js" onclick="alert(1)', [['<&', 'Token "String"'], ['text'], ['', 'Token Text']])).toBe(
+    '<pre><code class="language-js&quot; onclick=&quot;alert(1)"><span class="Token &quot;String&quot;">&lt;&amp;</span>\n<span class="Token Unknown">text</span>\n<span class="Token Text"></span>\n</code></pre>\n',
+  )
+})

--- a/packages/markdown-worker/test/RenderMarkdown.test.ts
+++ b/packages/markdown-worker/test/RenderMarkdown.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from '@jest/globals'
+import { PlainMessagePortRpc } from '@lvce-editor/rpc'
+import { RendererWorker, SyntaxHighlightingWorker } from '@lvce-editor/rpc-registry'
+import { initializeSyntaxHighlightingWorker } from '../src/parts/InitializeSyntaxHighlightingWorker/InitializeSyntaxHighlightingWorker.ts'
 import * as RenderMarkdown from '../src/parts/RenderMarkdown/RenderMarkdown.ts'
 
 test('empty string', async () => {
@@ -64,6 +67,90 @@ test('link - external', async () => {
 
 test('code block', async () => {
   expect(await RenderMarkdown.renderMarkdown('```\ncode\n```')).toBe('<pre><code>code\n</code></pre>\n')
+})
+
+test('code block - unknown language', async () => {
+  expect(await RenderMarkdown.renderMarkdown('```unknown\ncode\n```')).toBe('<pre><code class="language-unknown">code\n</code></pre>\n')
+})
+
+test('code block - syntax highlighted using contributed extension alias', async () => {
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    async 'SendMessagePortToSyntaxHighlightingWorker.sendMessagePortToSyntaxHighlightingWorker'(port: MessagePort): Promise<void> {
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'Tokenizer.tokenizeCodeBlock': () => [['git', 'Token Command', ' status', 'Token Text']],
+        },
+        messagePort: port,
+      })
+    },
+  })
+  await initializeSyntaxHighlightingWorker()
+
+  expect(
+    await RenderMarkdown.renderMarkdown('```sh\ngit status\n```', {
+      languages: [
+        {
+          extensions: ['.sh'],
+          id: 'shellscript',
+          tokenize: '/extensions/shellscript/tokenize.js',
+        },
+      ],
+    }),
+  ).toBe('<pre><code class="language-sh"><span class="Token Command">git</span><span class="Token Text"> status</span>\n</code></pre>\n')
+  expect(mockRendererRpc.invocations).toEqual([
+    [
+      'SendMessagePortToSyntaxHighlightingWorker.sendMessagePortToSyntaxHighlightingWorker',
+      expect.anything(),
+      'HandleMessagePort.handleMessagePort2',
+    ],
+  ])
+  await SyntaxHighlightingWorker.dispose()
+})
+
+test('code block - keeps normal escaped output when syntax highlighting fails', async () => {
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    async 'SendMessagePortToSyntaxHighlightingWorker.sendMessagePortToSyntaxHighlightingWorker'(port: MessagePort): Promise<void> {
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'Tokenizer.tokenizeCodeBlock': () => {
+            throw new Error('tokenizer failed')
+          },
+        },
+        messagePort: port,
+      })
+    },
+  })
+  await initializeSyntaxHighlightingWorker()
+
+  expect(
+    await RenderMarkdown.renderMarkdown('```javascript\nconst value = "<unsafe>"\n```', {
+      languages: [{ id: 'javascript', tokenize: '/extensions/javascript/tokenize.js' }],
+    }),
+  ).toBe('<pre><code class="language-javascript">const value = &quot;&lt;unsafe&gt;&quot;\n</code></pre>\n')
+  expect(mockRendererRpc.invocations).toHaveLength(1)
+  await SyntaxHighlightingWorker.dispose()
+})
+
+test('code block - keeps normal output for invalid tokenizer response', async () => {
+  using mockRendererRpc = RendererWorker.registerMockRpc({
+    async 'SendMessagePortToSyntaxHighlightingWorker.sendMessagePortToSyntaxHighlightingWorker'(port: MessagePort): Promise<void> {
+      await PlainMessagePortRpc.create({
+        commandMap: {
+          'Tokenizer.tokenizeCodeBlock': () => ({}),
+        },
+        messagePort: port,
+      })
+    },
+  })
+  await initializeSyntaxHighlightingWorker()
+
+  expect(
+    await RenderMarkdown.renderMarkdown('```javascript\nconst value = 1\n```', {
+      languages: [{ id: 'javascript', tokenize: '/extensions/javascript/tokenize.js' }],
+    }),
+  ).toBe('<pre><code class="language-javascript">const value = 1\n</code></pre>\n')
+  expect(mockRendererRpc.invocations).toHaveLength(1)
+  await SyntaxHighlightingWorker.dispose()
 })
 
 test('list', async () => {


### PR DESCRIPTION
Highlight fenced code blocks in extension markdown by connecting the markdown worker to the syntax-highlighting worker. Resolve contributed language ids and file-extension aliases, emit escaped token spans, and retain normal code rendering on failures.