### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,12 +3,21 @@ import * as actions from '@lvce-editor/eslint-plugin-github-actions'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   ...actions.default,
   {
     rules: {
+      'jest/expect-expect': 'off',
+      'jest/no-disabled-tests': 'off',
       'sonarjs/assertions-in-tests': 'off',
       'unicorn/no-break-in-nested-loop': 'off',
       'unicorn/no-global-object-property-assignment': 'off',
+    },
+  },
+  {
+    files: ['packages/markdown-worker/test/**/*.ts'],
+    rules: {
+      'virtual-dom/prefer-constants': 'off',
     },
   },
 ]

--- a/packages/markdown-worker/src/parts/ParseHtml/ParseHtml.ts
+++ b/packages/markdown-worker/src/parts/ParseHtml/ParseHtml.ts
@@ -1,5 +1,5 @@
 import type { VirtualDomNode } from '@lvce-editor/virtual-dom-worker'
-import { text } from '@lvce-editor/virtual-dom-worker'
+import { text, VirtualDomElements } from '@lvce-editor/virtual-dom-worker'
 import * as Assert from '../Assert/Assert.ts'
 import * as GetVirtualDomTag from '../GetVirtualDomTag/GetVirtualDomTag.ts'
 import * as HtmlTokenType from '../HtmlTokenType/HtmlTokenType.ts'
@@ -14,7 +14,7 @@ export const parseHtml = (html: string, allowedAttributes: readonly string[]): r
   const dom: VirtualDomNode[] = []
   const root: VirtualDomNode = {
     childCount: 0,
-    type: 0,
+    type: VirtualDomElements.Root,
   }
   let current: any = root
   const stack: VirtualDomNode[] = [root]


### PR DESCRIPTION
Enable the shared recommended virtual-DOM ESLint preset.

- use `VirtualDomElements.Root` for the parser sentinel
- keep raw virtual-DOM fixture values allowed in tests
- preserve intentional async/no-assertion and skipped tests under the updated Jest lint defaults

Validation:
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` (91 passed, 3 skipped)
- `npm run measure` (usedSize: 578376)