### PR TITLE
fix: decode quotes in markdown text

### DIFF
--- a/packages/markdown-worker/src/parts/ParseText/ParseText.ts
+++ b/packages/markdown-worker/src/parts/ParseText/ParseText.ts
@@ -1,3 +1,3 @@
 export const parseText = (text: string): string => {
-  return text.replaceAll('&gt;', '>').replaceAll('&lt;', '<').replaceAll('&amp;', '&')
+  return text.replaceAll('&gt;', '>').replaceAll('&lt;', '<').replaceAll('&quot;', '"').replaceAll('&#39;', "'").replaceAll('&amp;', '&')
 }

--- a/packages/markdown-worker/test/ParseHtml.test.ts
+++ b/packages/markdown-worker/test/ParseHtml.test.ts
@@ -166,6 +166,18 @@ test('text with angle bracket', () => {
   ])
 })
 
+test('text with quotes', () => {
+  const html = '<h2>&quot;What&#39;s Changed&quot;</h2>'
+  const allowedAttributes: readonly string[] = []
+  expect(ParseHtml.parseHtml(html, allowedAttributes)).toEqual([
+    {
+      childCount: 1,
+      type: VirtualDomElements.H2,
+    },
+    text('"What\'s Changed"'),
+  ])
+})
+
 test('closing tag updates current element correctly', () => {
   const html = '<div><p>text</p><span>more</span></div>'
   const allowedAttributes: readonly string[] = []


### PR DESCRIPTION
Decode escaped apostrophes and quotation marks when converting rendered Markdown HTML to virtual DOM text. This prevents changelog headings such as ‘What's Changed’ from displaying their HTML entities.