### PR TITLE
fix: render content after horizontal rules

### DIFF
--- a/packages/markdown-worker/src/parts/IsSelfClosingTag/IsSelfClosingTag.ts
+++ b/packages/markdown-worker/src/parts/IsSelfClosingTag/IsSelfClosingTag.ts
@@ -2,6 +2,7 @@ import * as ElementTags from '../ElementTags/ElementTags.ts'
 
 export const isSelfClosingTag = (tag: string): boolean => {
   switch (tag) {
+    case ElementTags.Hr:
     case ElementTags.Img:
       return true
     default:

--- a/packages/markdown-worker/src/parts/ParseHtml/ParseHtml.ts
+++ b/packages/markdown-worker/src/parts/ParseHtml/ParseHtml.ts
@@ -21,6 +21,7 @@ export const parseHtml = (html: string, allowedAttributes: readonly string[]): r
   let current: any = root
   const stack: VirtualDomNode[] = [root]
   let attributeName = ''
+  let currentTagIsSelfClosing = false
   for (const token of tokens) {
     switch (token.type) {
       case HtmlTokenType.AttributeName:
@@ -39,6 +40,12 @@ export const parseHtml = (html: string, allowedAttributes: readonly string[]): r
         current.childCount++
         dom.push(text(ParseText.parseText(token.text)))
         break
+      case HtmlTokenType.ClosingAngleBracket:
+        if (currentTagIsSelfClosing) {
+          current = stack.at(-1) || root
+          currentTagIsSelfClosing = false
+        }
+        break
       case HtmlTokenType.TagNameEnd:
         stack.pop()
         current = stack.at(-1) || root
@@ -50,7 +57,8 @@ export const parseHtml = (html: string, allowedAttributes: readonly string[]): r
           type: GetVirtualDomTag.getVirtualDomTag(token.text),
         }
         dom.push(current)
-        if (!IsSelfClosingTag.isSelfClosingTag(token.text)) {
+        currentTagIsSelfClosing = IsSelfClosingTag.isSelfClosingTag(token.text)
+        if (!currentTagIsSelfClosing) {
           stack.push(current)
         }
         break

--- a/packages/markdown-worker/src/parts/ParseHtml/ParseHtml.ts
+++ b/packages/markdown-worker/src/parts/ParseHtml/ParseHtml.ts
@@ -36,15 +36,15 @@ export const parseHtml = (html: string, allowedAttributes: readonly string[]): r
         }
         attributeName = ''
         break
-      case HtmlTokenType.Content:
-        current.childCount++
-        dom.push(text(ParseText.parseText(token.text)))
-        break
       case HtmlTokenType.ClosingAngleBracket:
         if (currentTagIsSelfClosing) {
           current = stack.at(-1) || root
           currentTagIsSelfClosing = false
         }
+        break
+      case HtmlTokenType.Content:
+        current.childCount++
+        dom.push(text(ParseText.parseText(token.text)))
         break
       case HtmlTokenType.TagNameEnd:
         stack.pop()

--- a/packages/markdown-worker/test/GetMarkdownVirtualDom.test.ts
+++ b/packages/markdown-worker/test/GetMarkdownVirtualDom.test.ts
@@ -65,6 +65,31 @@ test('nested elements', () => {
   ])
 })
 
+test('horizontal rule with sibling elements', () => {
+  expect(GetMarkdownVirtualDom.getMarkdownVirtualDom('<p>First</p><hr><p>Second</p>')).toEqual([
+    {
+      childCount: 3,
+      className: 'Markdown',
+      role: 'document',
+      type: VirtualDomElements.Div,
+    },
+    {
+      childCount: 1,
+      type: VirtualDomElements.P,
+    },
+    text('First'),
+    {
+      childCount: 0,
+      type: VirtualDomElements.Hr,
+    },
+    {
+      childCount: 1,
+      type: VirtualDomElements.P,
+    },
+    text('Second'),
+  ])
+})
+
 test('throws error for non-string input', () => {
   // @ts-expect-error
   expect(() => GetMarkdownVirtualDom.getMarkdownVirtualDom(123)).toThrow()


### PR DESCRIPTION
Fix Markdown virtual DOM parsing so horizontal rules remain void elements and following content stays at the document root. Add regression coverage for sibling content after an hr element.